### PR TITLE
Add dark section

### DIFF
--- a/@davidway/gatsby-theme-novela/src/components/MDX/MDX.tsx
+++ b/@davidway/gatsby-theme-novela/src/components/MDX/MDX.tsx
@@ -20,10 +20,12 @@ import Figcaption from '@components/Figcaption';
 import * as shortcodes from '@blocks/kit';
 import mediaqueries from '@styles/media';
 import { toKebabCase } from '@utils';
+import PostSection from '@components/PostSection';
 
 const components = {
   ...shortcodes,
   img: ImageZoom,
+  section: PostSection,
   a: Anchor,
   blockquote: Blockquote,
   h1: Headings.h2, // h1 reserved article title

--- a/@davidway/gatsby-theme-novela/src/components/PostSection/PostSection.tsx
+++ b/@davidway/gatsby-theme-novela/src/components/PostSection/PostSection.tsx
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+
+const PostSection = styled.section<{ dark?: boolean }>`
+  position: relative;
+  left: -68px;
+  padding-left: 68px;
+  width: 100vw;
+  margin: 25px auto 60px;
+
+  ${({ dark }) => dark && `
+    background: #1D2128;
+
+    > * {
+      color: white;
+    }
+  `}
+`;
+
+export default PostSection;

--- a/@davidway/gatsby-theme-novela/src/components/PostSection/index.ts
+++ b/@davidway/gatsby-theme-novela/src/components/PostSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PostSection'


### PR DESCRIPTION
Add the dark attribute to the section element to use it within a post.

```
<section dark>
  ...Content you want to be in a dark section...
</section>
```

## In Light mode
![Screenshot 2021-07-31 at 14-48-34 Understanding the Gatsby lifecycle with Narative](https://user-images.githubusercontent.com/6078452/127741989-eb72ca5c-1d81-4072-8cee-f83abe23288b.png)

## In Dark Mode
![Screenshot 2021-07-31 at 14-52-13 Understanding the Gatsby lifecycle with Narative](https://user-images.githubusercontent.com/6078452/127742038-f6ee1dcf-e9d1-46b6-91cc-388fb34b209e.png)
